### PR TITLE
test: OWASP dependency-check cache hand-off (do not merge)

### DIFF
--- a/.github/actions/maven-owasp-scan/action.yml
+++ b/.github/actions/maven-owasp-scan/action.yml
@@ -13,6 +13,13 @@ inputs:
     description: OWASP data directory path
     required: false
     default: /tmp/.owasp/dependency-check-data
+  auto-update:
+    description: >-
+      Whether dependency-check may update the NVD database from the NVD API.
+      PR scans set this to false and rely on a pre-hydrated, cached database
+      (see owasp-nvd-hydrate.yml) so they never hit the rate-limited NVD API.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -21,6 +28,7 @@ runs:
       env:
         OWASP_VERSION: ${{ inputs.owasp-version }}
         OWASP_DATA_DIRECTORY: ${{ inputs.data-directory }}
+        OWASP_AUTO_UPDATE: ${{ inputs.auto-update }}
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
@@ -29,8 +37,8 @@ runs:
           -Dformat=JSON \
           -DprettyPrint=true \
           -DfailOnError=false \
+          -DautoUpdate=$OWASP_AUTO_UPDATE \
           -DossindexAnalyzerEnabled=true \
-          -DnvdApiAnalyzerEnabled=false \
           -DnodeAnalyzerEnabled=false \
           -DassemblyAnalyzerEnabled=false \
           -DcentralAnalyzerEnabled=false \

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           merge_base=$(gh api -q '.merge_base_commit.sha' \
             "/repos/$REPO/compare/$BASE_REF...$HEAD_SHA")
-          echo "sha=$merge_base" >> $GITHUB_OUTPUT
+          echo "sha=$merge_base" >> "$GITHUB_OUTPUT"
           echo "Using merge base: $merge_base"
 
       - name: Checkout base branch
@@ -78,47 +78,49 @@ jobs:
           java-version: 17
           cache: maven
 
-      - name: Get date for cache key
-        if: needs.changes.outputs.codechange == 'true'
-        id: get-date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Restore OWASP database cache
+      # Restore the NVD database pre-built by owasp-nvd-hydrate.yml (scheduled on
+      # the default branch). Read-only: PR runs never update the NVD database, so
+      # they never contact the rate-limited NVD API. Fork PRs can read caches
+      # created on the base repo's default branch, so this works for forks too.
+      - name: Restore hydrated NVD database
         if: needs.changes.outputs.codechange == 'true'
         uses: actions/cache/restore@v4
         id: cache-owasp-restore
         with:
           path: /tmp/.owasp/dependency-check-data
-          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}
           restore-keys: |
-            owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-
-            owasp-cache-${{ runner.os }}-
+            owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-
+          key: owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-restore-only
+
+      # If the hydrated database is missing (cache evicted, or hydration has not
+      # run yet) neutralize rather than fail: a missing database is an infra gap,
+      # not a CVE regression in the PR. The scheduled job repopulates the cache.
+      - name: Skip if NVD database unavailable
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-matched-key == ''
+        run: |
+          echo "::warning::Hydrated OWASP NVD database cache not found; skipping the dependency check for this run."
+          echo "::warning::Trigger the 'OWASP NVD Database Hydration' workflow to repopulate the cache."
 
       - name: Run OWASP check on base branch
-        if: needs.changes.outputs.codechange == 'true'
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-matched-key != ''
         uses: ./.github/actions/maven-owasp-scan
         with:
           working-directory: base
           owasp-version: ${{ env.OWASP_VERSION }}
           data-directory: /tmp/.owasp/dependency-check-data
-
-      - name: Save OWASP cache after base scan
-        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/.owasp/dependency-check-data
-          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}-partial
+          auto-update: 'false'
 
       - name: Run OWASP check on PR branch
-        if: needs.changes.outputs.codechange == 'true'
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-matched-key != ''
         uses: ./.github/actions/maven-owasp-scan
         with:
           working-directory: .
           owasp-version: ${{ env.OWASP_VERSION }}
           data-directory: /tmp/.owasp/dependency-check-data
+          auto-update: 'false'
 
       - name: Compare and fail on new CVEs above threshold
-        if: needs.changes.outputs.codechange == 'true'
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-matched-key != ''
         run: |
           # Extract CVEs above threshold from both branches (CVSS >= $CVSS_THRESHOLD)
           threshold=$CVSS_THRESHOLD
@@ -180,13 +182,6 @@ jobs:
           else
             echo "✅ No new vulnerabilities introduced"
           fi
-
-      - name: Save OWASP database cache
-        if: needs.changes.outputs.codechange == 'true' && always()
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/.owasp/dependency-check-data
-          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}
 
       - name: Upload reports
         if: needs.changes.outputs.codechange == 'true' && always()

--- a/.github/workflows/owasp-nvd-hydrate.yml
+++ b/.github/workflows/owasp-nvd-hydrate.yml
@@ -1,0 +1,74 @@
+name: OWASP NVD Database Hydration
+permissions:
+  contents: read
+# Builds/refreshes the OWASP dependency-check NVD database and publishes it to the
+# Actions cache. The PR-triggered owasp-dependency-check workflow then runs with
+# -DautoUpdate=false against this cache, so PR runs (including those from forks)
+# never contact the rate-limited NVD API. Isolating the NVD pull here means a
+# transient NVD outage retries/reruns on a schedule instead of failing PRs.
+on:
+  schedule:
+    # Twice daily keeps the cache inside the 7-day Actions cache retention window.
+    - cron: '0 */12 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  hydrate:
+    runs-on: ubuntu-latest
+    # Hard backstop so a persistent NVD outage can never burn a full 6h runner.
+    timeout-minutes: 180
+    env:
+      OWASP_VERSION: 12.1.3
+      OWASP_DATA_DIRECTORY: /tmp/.owasp/dependency-check-data
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      # Restore the previous database so the update is incremental, not a full pull.
+      - name: Restore previous NVD database
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.owasp/dependency-check-data
+          restore-keys: |
+            owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-
+          key: owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-restore-only
+
+      # Retry the NVD update many times so a transient NVD outage (503/524, rate
+      # limiting) clears without anyone re-running the job by hand. The job-level
+      # timeout-minutes above is the hard backstop.
+      - name: Update NVD database
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          # Optional: speeds up and stabilizes updates (50 vs 5 requests / 30s).
+          # Available here because scheduled runs execute in a trusted context.
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        with:
+          max_attempts: 30
+          timeout_minutes: 40
+          retry_wait_seconds: 120
+          retry_on: error
+          warning_on_retry: true
+          shell: bash
+          command: |
+            mvn -B org.owasp:dependency-check-maven:$OWASP_VERSION:update-only \
+              -DnvdValidForHours=0 \
+              ${NVD_API_KEY:+-DnvdApiKey=$NVD_API_KEY} \
+              -DdataDirectory=$OWASP_DATA_DIRECTORY
+
+      # Unique key per run; PR runs select the newest via the shared restore-keys
+      # prefix. Cache keys are immutable, so a rotating suffix is required.
+      - name: Save NVD database cache
+        if: always() && hashFiles('/tmp/.owasp/dependency-check-data/**') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/.owasp/dependency-check-data
+          key: owasp-nvd-db-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ github.run_id }}

--- a/.github/workflows/owasp-nvd-hydrate.yml
+++ b/.github/workflows/owasp-nvd-hydrate.yml
@@ -46,6 +46,7 @@ jobs:
       # limiting) clears without anyone re-running the job by hand. The job-level
       # timeout-minutes above is the hard backstop.
       - name: Update NVD database
+        id: nvd_update
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           # Optional: speeds up and stabilizes updates (50 vs 5 requests / 30s).
@@ -66,8 +67,10 @@ jobs:
 
       # Unique key per run; PR runs select the newest via the shared restore-keys
       # prefix. Cache keys are immutable, so a rotating suffix is required.
+      # Guard on the update step's outcome rather than hashFiles(): hashFiles can
+      # only see files under GITHUB_WORKSPACE, and the data dir lives in /tmp.
       - name: Save NVD database cache
-        if: always() && hashFiles('/tmp/.owasp/dependency-check-data/**') != ''
+        if: steps.nvd_update.outcome == 'success'
         uses: actions/cache/save@v4
         with:
           path: /tmp/.owasp/dependency-check-data

--- a/README.md
+++ b/README.md
@@ -178,3 +178,5 @@ Please refer to the [contribution guidelines](https://github.com/prestodb/presto
 
 By contributing to Presto, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](LICENSE).
 
+
+<!-- owasp ci test: trivial change to trigger dependency-check (remove later) -->


### PR DESCRIPTION
Throwaway PR to verify the dependency-check job restores the hydrated NVD cache and scans with autoUpdate=false. Do not merge.